### PR TITLE
Update hf_examples.md to include the build step for prompt injection model

### DIFF
--- a/docs/hf_examples.md
+++ b/docs/hf_examples.md
@@ -99,6 +99,13 @@ export DETECTOR_DIR=$DETECTOR_STORAGE/$DETECTOR_NAME
 huggingface-cli download "$HF_MODEL" --local-dir "$DETECTOR_DIR"
 ```
 
+- Build the image again to include the new model:
+
+```bash
+export HF_IMAGE=hf-detector:latest
+podman build -f detectors/Dockerfile.hf -t $HF_IMAGE detectors
+```
+
 - then spin up the container as before:
 
 ```bash


### PR DESCRIPTION
fix missing build step in prompt injection detection


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified detector setup instructions by adding a rebuild step after model downloads for both toxic content and prompt-injection detectors, ensuring the container image includes the new models.
  * Included example commands to set an image tag and rebuild with Podman for a smoother setup experience.
  * Corrected minor code block formatting to improve readability.
  * No application behavior or runtime changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->