### PR TITLE
Enable dynamic versioning via setuptools-scm

### DIFF
--- a/detectors/pyproject.toml
+++ b/detectors/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "guardrails-detectors"
-version = "0.3.0"
+dynamic = ["version"]
 requires-python = ">=3.11"
 description = "A collection of detectors for the FMS Guardrails Orchestrator"
 license = "Apache-2.0"
@@ -46,8 +46,12 @@ dev = [
 ]
 
 [build-system]
-requires = ["setuptools>=80.9.0"]
+requires = ["setuptools>=80.9.0", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 packages = []
+
+[tool.setuptools_scm]
+root = ".."
+version_scheme = "no-guess-dev"


### PR DESCRIPTION
## Summary

- Derive package version from git tags (e.g. `v0.3.0+rhaiv.1`) instead of a hardcoded string
- Adds `setuptools-scm>=8` as a build dependency
- Configures `root = ".."` since `pyproject.toml` lives in `detectors/` subdirectory
- Uses `no-guess-dev` version scheme to avoid guessing next version on dirty trees

## Why midstream-only

This is a midstream-specific change. Upstream keeps a static `version = "0.3.0"` in pyproject.toml. Midstream needs dynamic versioning because RHOAI release tags (`v0.3.0+rhaiv.1`) drive the wheel version for the AIPCC index.

## Test plan

- [x] Verified `setuptools-scm` resolves to `0.3.0+rhaiv.1` at the current tag on a clean tree
- [ ] After merge, re-tag on the new commit to ensure clean version output


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build system to use automated version management instead of manual versioning, ensuring consistency between project metadata and release tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->